### PR TITLE
Made the collision code return a pair of results for both targets

### DIFF
--- a/boids/src/logic/boid.ts
+++ b/boids/src/logic/boid.ts
@@ -102,39 +102,47 @@ export const collideAndBounceOffCanvas = (boid: Boid, canvas: HTMLCanvasElement)
     };
 }
 
-export const collideAndBounceOffOtherBoid = (a: Boid, b: Boid): CollisionResult | null => {
+export const generateCollisionBouncePair = (a: Boid, b: Boid): [CollisionResult, CollisionResult] | null => {
 
     const radii2: number = Math.pow(a.radius + b.radius, 2);
-    const delta: Vector2 = vector.sub(b.pos, a.pos);
-    const mag2: number = vector.mag2(delta);
+    const mag2: number = vector.mag2(vector.sub(b.pos, a.pos));
 
     if (mag2 > radii2) return null;
-
-    let pos: Vector2 = {...a.pos};
-    let vel: Vector2 = {...a.vel};
 
     //dist between both boids
     const mag = Math.sqrt(mag2);
 
-    //coefficient for how much to push a's radii vs b's radii as they could be different
-    const coeff = (a.radius / b.radius) / mag;
+    const generateCollisionBounce = (a: Boid, b: Boid) => {
+        const delta: Vector2 = vector.sub(b.pos, a.pos);
 
-    //Separate the boid from the other
-    const pushOffset: Vector2 = vector.scale(delta, -0.5 * coeff);
+        let pos: Vector2 = {...a.pos};
+        let vel: Vector2 = {...a.vel};
 
-    pos.x += pushOffset.x;
-    pos.y += pushOffset.y;
+        //coefficient for how much to push a's radii vs b's radii as they could be different
+        const coeff = (a.radius / b.radius) / mag;
 
-    //Make the boid bounce off the other
-    const leftNormal = vector.leftNormal(delta);
-    const reflect = vector.normalized(vector.reflect(b.vel, leftNormal));
-    const velSpeed: number = vector.mag(a.vel);
+        //Separate the boid from the other
+        const pushOffset: Vector2 = vector.scale(delta, -0.5 * coeff);
 
-    vel.x = reflect.x * velSpeed;
-    vel.y = reflect.y * velSpeed;
+        pos.x += pushOffset.x;
+        pos.y += pushOffset.y;
 
-    return {
-        newPos: pos,
-        newVelocity: vel
-    };
+        //Make the boid bounce off the other
+        const leftNormal = vector.leftNormal(delta);
+        const reflect = vector.normalized(vector.reflect(b.vel, leftNormal));
+        const velSpeed: number = vector.mag(a.vel);
+
+        vel.x = reflect.x * velSpeed;
+        vel.y = reflect.y * velSpeed;
+
+        return {
+            newPos: pos,
+            newVelocity: vel
+        };
+    }
+
+    return [
+        generateCollisionBounce(a,b),
+        generateCollisionBounce(b,a)
+    ];
 }

--- a/boids/src/logic/sim.ts
+++ b/boids/src/logic/sim.ts
@@ -1,7 +1,7 @@
 import {
     Boid,
     collideAndBounceOffCanvas,
-    collideAndBounceOffOtherBoid,
+    generateCollisionBouncePair,
     createRandomlyOnACanvas,
     randomizeVelocityDirection,
     update
@@ -225,29 +225,22 @@ export const createSim = () => {
         for (let i = 0; i < boids.length; i++) {
             const a: Boid = boids[i];
 
-            for (let k = 0; k < boids.length; k++) {
-
-                //same boid
-                if (k === i) continue;
+            for (let k = i+1; k < boids.length; k++) {
 
                 const b: Boid = boids[k];
 
-                const avb = collideAndBounceOffOtherBoid(a, b);
+                const collisionPair = generateCollisionBouncePair(a, b);
 
-                if (avb) {
+                if (collisionPair) {
+                    const [resA, resB] = collisionPair;
 
-                    const bva = collideAndBounceOffOtherBoid(b, a);
-
-                    a.pos = avb.newPos;
-                    a.vel = avb.newVelocity;
+                    a.pos = resA.newPos;
+                    a.vel = resA.newVelocity;
                     a.collisionCoolDownSeconds = 1;
 
-                    //Technically bva won't ever be null as avb wasn't but this pleases my brain :)
-                    if (bva) {
-                        b.pos = bva.newPos;
-                        b.vel = bva.newVelocity;
-                        b.collisionCoolDownSeconds = 1;
-                    }
+                    b.pos = resB.newPos;
+                    b.vel = resB.newVelocity;
+                    b.collisionCoolDownSeconds = 1;
                 }
             }
         }


### PR DESCRIPTION
I noticed the comment you left in this code, and I thought it can actually be done even cleaner :). By leveraging the fact that the collision always happens between two objects, we can encode that on the type level by making the detector return a pair of results automatically. This also leverages some of the previously computed results (like the distance check) since it'll be the same for both.

Additionally, you can avoid the `i == k` check by starting the second loop from the index after the previous one. This effectively creates a triangular matrix, i.e. what you want for collision.